### PR TITLE
As discussed, replace resolve by resolveonly (no dash for consistency), add noresolve

### DIFF
--- a/README
+++ b/README
@@ -20,8 +20,11 @@ DESCRIPTION
        -t, --test
               Test if there are any gems to update
 
-       -r, --resolve
+       -r, --resolveonly
               Resolve the gem depencies and exit
+
+       -n, --noresolve
+              Do not resolve any dependencies, this is useful for generating (-create) a single package
 
        --noautodepends
               Disable automatic dependency generation for shared objects (*.so)

--- a/pacgem
+++ b/pacgem
@@ -353,7 +353,7 @@ module Pacgem
 
     def install(name, version = nil)
       resolve(Gem::Dependency.new(name, version)).explicit = true
-      if @options[:resolve]
+      if @options[:resolveonly]
         exit
       end
     end
@@ -384,7 +384,7 @@ module Pacgem
         else
           @logger.msg2 "(New) #{spec.full_name}: #{spec.summary}"
         end
-        spec.runtime_dependencies.each {|d| resolve(d) }
+        spec.runtime_dependencies.each {|d| resolve(d) } if !@options[:noresolve]
         @list << pkg if @options[:create] || !pkg.installed?
         pkg
       end
@@ -516,8 +516,12 @@ Options:
         @options[:test] = true
       end
 
-      opts.on('-r', '--resolve', :NONE, 'Resolve dependencies') do
-        @options[:resolve] = true
+      opts.on('-r', '--resolveonly', :NONE, 'Resolve dependencies only, don\'t install anything') do
+        @options[:resolveonly] = true
+      end
+
+      opts.on('-n', '--noresolve', :NONE, 'Do not resolve dependencies') do
+        @options[:noresolve] = true
       end
 
       opts.on('--noautodepends', :NONE, 'Disable automatic dependency generation for shared objects (*.so)') do

--- a/pacgem.8
+++ b/pacgem.8
@@ -16,6 +16,15 @@ Create package only, do not install
 \fB\-u\fR, \fB\-\-update\fR
 Update all installed gems
 .TP
+\fB\-t\fR, \fB\-\-test\fR
+Test if there are any gems to update
+.TP
+\fB\-r\fR, \fB\-\-resolveonly\fR
+Resolve the gem depencies and exit
+.TP
+\fB\-r\fR, \fB\-\-noresolve\fR
+Do not resolve any dependencies, this is useful for generating (-create) a single package
+.TP
 \fB\-\-noautodepends\fR
 Disable automatic dependency generation for shared objects (*.so)
 .TP


### PR DESCRIPTION
The noresolve seems to do what I want it to, but could you have an extra look at it?

It is meant primarily for creating a single package (eg. rails), without needing to wait for all dependencies to be created too (because they might already be installed for example)
