### PR TITLE
Fix typo in open(uri...)

### DIFF
--- a/pacgem
+++ b/pacgem
@@ -213,7 +213,7 @@ module Pacgem
 
     def download
       gemfile = "#{gemname}-#{version}.gem"
-      open("#{uri}gems/#{gemfile}") do |i|
+      open("#{uri}/gems/#{gemfile}") do |i|
         File.open(gemfile, 'w') do |o|
           FileUtils.copy_stream(i, o)
         end


### PR DESCRIPTION
There was a missing slash on line 216 causing this program
to try to resolve hosts such as "gems.rubyforge.orggems".
