### PR TITLE
fix typo in man page

### DIFF
--- a/pacgem.8
+++ b/pacgem.8
@@ -22,7 +22,7 @@ Test if there are any gems to update
 \fB\-r\fR, \fB\-\-resolveonly\fR
 Resolve the gem depencies and exit
 .TP
-\fB\-r\fR, \fB\-\-noresolve\fR
+\fB\-n\fR, \fB\-\-noresolve\fR
 Do not resolve any dependencies, this is useful for generating (-create) a single package
 .TP
 \fB\-\-noautodepends\fR


### PR DESCRIPTION
man page is not consistent with README, '--resolveonly' and '--noresolve' have the same short switch '-r'.
